### PR TITLE
TVM Tuned Ops not written to disk

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -28,7 +28,9 @@ def main():
     args = parser.parse_args()
 
     with open(args.json_file, 'r') as file:
-        for json_obj in json.load(file):
+        data = json.load(file)
+        for _, json_obj in enumerate(data):
             run_subprocess(json_obj)
+            print(f"Job Progress [{_}/{len(data)}]")
 
 main()

--- a/tdef/src/tdef.py
+++ b/tdef/src/tdef.py
@@ -84,7 +84,10 @@ def create_hashed_dir(data_dict):
     records_filename = os.path.join(model_dir, f"records.json")
     already_existed = os.path.exists(records_filename) and os.path.isfile(records_filename)
     if already_existed:
-        already_existed = os.path.getsize(records_filename) > 10
+        file_size_ok = os.path.getsize(records_filename) > 10
+        already_existed = file_size_ok
+        if not file_size_ok:
+            print("Found records but file size was < 10 bytes, so probably failed previously. Will rerun")
     os.makedirs(model_dir, exist_ok=True)
     with open(metadata_filename, 'w') as file:
         file.write(json.dumps(data_dict, indent=2))


### PR DESCRIPTION
Fixed this now and tidied up the tuning method. Also gives a print out when an empty records file is loaded.